### PR TITLE
CD-289 main menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -38,7 +38,7 @@ add_action( 'wp_enqueue_scripts', 'common_design_theme_scripts' );
 /**
  * Add "menu-item--expanded" class to parent menu items.
  */
-function add_menu_parent_class( $items ) {
+function cd_add_menu_parent_class( $items ) {
 	$parents = array();
 	foreach ( $items as $item ) {
 		//Check if the item is a parent item
@@ -56,12 +56,12 @@ function add_menu_parent_class( $items ) {
 
 	return $items;
 }
-add_filter( 'wp_nav_menu_objects', 'add_menu_parent_class' );
+add_filter( 'wp_nav_menu_objects', 'cd_add_menu_parent_class' );
 
 /**
  * Add "menu-item--active-trail" class to menu items.
  */
-function active_nav_class($classes, $item){
+function cd_active_nav_class($classes, $item){
 	if( in_array( 'current-menu-item', $classes ) ||
 	    in_array( 'current-menu-ancestor', $classes ) ||
 	    in_array( 'current-menu-parent', $classes ) ||
@@ -74,7 +74,7 @@ function active_nav_class($classes, $item){
 
 	return $classes;
 }
-add_filter('nav_menu_css_class' , 'active_nav_class' , 10 , 2);
+add_filter('nav_menu_css_class' , 'cd_active_nav_class' , 10 , 2);
 
 /**
  * Add "menu" class to sub menu.
@@ -87,7 +87,7 @@ add_filter( 'nav_menu_submenu_css_class', 'cd_nav_menu_submenu_css_class' );
 
 
 /**
- * Add custom attribute and value to a nav menu items anchor.
+ * Add an ID attribute and value to nav menu links.
  */
 add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args ) {
 	$atts['id'] = 'cd-main-menu-item-' . $item->ID;
@@ -97,6 +97,8 @@ add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args ) {
 
 /**
  * Custom walker class.
+ * This outputs the Main Menu markup needed for the cd-dropdown.js to work when menu items that have children.
+ * It adds ids, classes and custom data attributes to the menu, menu items and menu item links.
  */
 class cd_MainNav_Walker extends Walker_Nav_Menu {
 	private $curItem;
@@ -122,6 +124,7 @@ class cd_MainNav_Walker extends Walker_Nav_Menu {
 		);
 		$class_names = implode( ' ', $classes );
 
+		// Get the ID of the
 //		var_dump($this->curItem );
 		$curItemID = $this->curItem->ID;
 		$curItemTitle = $this->curItem->title;

--- a/functions.php
+++ b/functions.php
@@ -29,13 +29,165 @@ function common_design_theme_stylesheets() {
 	wp_enqueue_style ('implementation-overrides', get_template_directory_uri().'/resources/assets/css/styles.css', array(), null, 'all' );
 }
 
-
-
 function common_design_theme_scripts() {
 	wp_enqueue_script( 'script', get_template_directory_uri() . '/resources/assets/js/cd-dropdown.js', array(), null, true );
 }
-
-
 add_action( 'wp_enqueue_scripts', 'common_design_theme_stylesheets' );
 add_action( 'wp_enqueue_scripts', 'common_design_theme_scripts' );
 
+
+//Add "menu-item--expanded" class to parent menu items
+function add_menu_parent_class( $items ) {
+	$parents = array();
+	foreach ( $items as $item ) {
+		//Check if the item is a parent item
+		if ( $item->menu_item_parent && $item->menu_item_parent > 0 ) {
+			$parents[] = $item->menu_item_parent;
+		}
+	}
+
+	foreach ( $items as $item ) {
+		if ( in_array( $item->ID, $parents ) ) {
+			//Add "menu-parent-item" class to parents
+			$item->classes[] = 'menu-item--expanded';
+		}
+	}
+
+	return $items;
+}
+add_filter( 'wp_nav_menu_objects', 'add_menu_parent_class' );
+
+//Add "menu-item--active-trail" class to menu items
+function active_nav_class($classes, $item){
+	if( in_array( 'current-menu-item', $classes ) ||
+	    in_array( 'current-menu-ancestor', $classes ) ||
+	    in_array( 'current-menu-parent', $classes ) ||
+	    in_array( 'current_page_parent', $classes ) ||
+	    in_array( 'current_page_ancestor', $classes )
+	) {
+
+		$classes[] = 'menu-item--active-trail ';
+	}
+
+	return $classes;
+}
+add_filter('nav_menu_css_class' , 'active_nav_class' , 10 , 2);
+
+//Add "menu" class to sub menu
+function cd_nav_menu_submenu_css_class( $classes ) {
+	$classes[] = 'menu cd-main-menu__dropdown';
+	return $classes;
+}
+add_filter( 'nav_menu_submenu_css_class', 'cd_nav_menu_submenu_css_class' );
+
+
+/**
+ * Add custom attribute and value to a nav menu items anchor.
+ */
+//add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args ) {
+//	if ( 12 === $item->ID ) { // change 12 to the ID of your menu item.
+//		$atts['data-cd-toggable'] = $item->title;
+//	}
+//
+//	return $atts;
+//}, 10, 3 );
+
+
+/**
+ * Custom walker class.
+ */
+class cd_MainNav_Walker extends Walker_Nav_Menu {
+
+	/**
+	 * Starts the list before the elements are added.
+	 *
+	 * Adds classes to the unordered list sub-menus.
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of arguments. @see wp_nav_menu()
+	 */
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
+		// Depth-dependent classes.
+		$indent = ( $depth > 0  ? str_repeat( "\t", $depth ) : '' ); // code indent
+		$display_depth = ( $depth + 1); // because it counts the first submenu as 0
+		$classes = array(
+			'menu',
+			'cd-main-menu__dropdown',
+//			( $display_depth % 2  ? 'menu-odd' : 'menu-even' ),
+//			( $display_depth >=2 ? 'sub-sub-menu' : '' ),
+//			'menu-depth-' . $display_depth
+		);
+		$class_names = implode( ' ', $classes );
+
+
+
+		$atts           = array();
+		$atts['data-cd-toggable'] = 'this';
+		$atts['data-cd-icon'] = 'arrow-down';
+		$atts['data-cd-component'] = 'cd-main-menu';
+//		$atts['data-cd-replace'] = 'cd-main-menu';
+
+
+		$attributes = 'data-cd-toggable';
+		foreach ( $atts as $attr => $value ) {
+			if ( is_scalar( $value ) && '' !== $value && false !== $value ) {
+				$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+				$attributes .= ' ' . $attr . '="' . $value . '"';
+			}
+		}
+		// Build HTML for output.
+		$output .= "\n" . $indent . '<ul id="cd-main-menu" class="' . $class_names . '" ' . $attributes . '>' . "\n";
+	}
+
+	/**
+	 * Start the element output.
+	 *
+	 * Adds main/sub-classes to the list items and links.
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param object $item   Menu item data object.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of arguments. @see wp_nav_menu()
+	 * @param int    $id     Current item ID.
+	 */
+	function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+		global $wp_query;
+		$indent = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent
+
+		// Depth-dependent classes.
+		$depth_classes = array(
+			( $depth == 0 ? 'main-menu-item' : 'sub-menu-item' ),
+			( $depth >=2 ? 'sub-sub-menu-item' : '' ),
+			( $depth % 2 ? 'menu-item-odd' : 'menu-item-even' ),
+			'menu-item-depth-' . $depth
+		);
+		$depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
+
+		// Passed classes.
+		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
+		$class_names = esc_attr( implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) ) );
+
+		// Build HTML.
+		$output .= $indent . '<li id="nav-menu-item-'. $item->ID . '" class="' . $class_names . '">';
+
+		// Link attributes.
+		$attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
+		$attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
+		$attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
+		$attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
+		$attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
+		$attributes .= ' class="menu-link ' . ( $depth > 0 ? 'sub-menu-link' : 'main-menu-link' ) . '"';
+
+		// Build HTML output and pass through the proper filter.
+		$item_output = sprintf( '%1$s<a%2$s>%3$s%4$s%5$s</a>%6$s',
+			$args->before,
+			$attributes,
+			$args->link_before,
+			apply_filters( 'the_title', $item->title, $item->ID ),
+			$args->link_after,
+			$args->after
+		);
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+	}
+}

--- a/resources/assets/js/cd-dropdown.js
+++ b/resources/assets/js/cd-dropdown.js
@@ -384,16 +384,17 @@ function initializeToggables() {
 
 
 /**
- * Update Drupal toggable nested menus.
+ * Update Wordpress toggable nested menus.
  */
-function updateDrupalTogglableMenus(selector) {
+function updateWordpressTogglableMenus(selector) {
   // If selector wasn't supplied, set the default.
-  selector = typeof selector !== 'undefined' ? selector : '.cd-nav .menu a + .menu';
+  selector = typeof selector !== 'undefined' ? selector : '.menu cd-main-menu__dropdown';
 
-  // Nested drupal menus are always toggable.
+  // Nested Wordpress menus are always toggable.
   var elements = document.querySelectorAll(selector);
   for (var i = 0, l = elements.length; i < l; i++) {
     this.setToggable(elements[i]);
+    console.log(elements[i]);
   }
 }
 
@@ -409,10 +410,10 @@ if (document.documentElement.classList.contains('js')) {
   this.handleResize = this.handleResize.bind(this);
   this.handleToggle = this.handleToggle.bind(this);
 
-  // Update nested Drupal menus in the header.
-  this.updateDrupalTogglableMenus();
-
   // Initialize toggable dropdown.
   this.initializeToggables();
+
+  // Update nested Wordpress menus in the header.
+  this.updateWordpressTogglableMenus();
 
 }

--- a/resources/assets/js/cd-dropdown.js
+++ b/resources/assets/js/cd-dropdown.js
@@ -388,13 +388,12 @@ function initializeToggables() {
  */
 function updateWordpressTogglableMenus(selector) {
   // If selector wasn't supplied, set the default.
-  selector = typeof selector !== 'undefined' ? selector : '.menu cd-main-menu__dropdown';
+  selector = typeof selector !== 'undefined' ? selector : '.menu.cd-main-menu__dropdown';
 
   // Nested Wordpress menus are always toggable.
   var elements = document.querySelectorAll(selector);
   for (var i = 0, l = elements.length; i < l; i++) {
     this.setToggable(elements[i]);
-    console.log(elements[i]);
   }
 }
 

--- a/resources/templates/nav/nav-top.php
+++ b/resources/templates/nav/nav-top.php
@@ -6,7 +6,14 @@
  */
 ?>
 
-<nav role="navigation" id="block-mainnavigation" aria-labelledby="block-mainnavigation-menu" data-cd-toggable="Menu" data-cd-component="cd-nav" data-cd-icon="arrow-down" class="block block-menu navigation menu--main cd-nav cd-site-header__nav">
+<nav role="navigation"
+     id="block-mainnavigation"
+     aria-labelledby="block-mainnavigation-menu"
+     data-cd-toggable="Menu"
+     data-cd-component="cd-nav"
+     data-cd-icon="arrow-down"
+     class="block block-menu navigation menu--main cd-nav cd-site-header__nav"
+     >
     <h2 id="block-mainnavigation-menu">Main navigation</h2>
 	<?php
 		wp_nav_menu( array(
@@ -22,44 +29,3 @@
 	?>
 </nav>
 
-<!---->
-<!--<nav role="navigation" id="block-mainnavigation" aria-labelledby="block-mainnavigation-menu" data-cd-toggable="Menu"-->
-<!--     data-cd-component="cd-nav" data-cd-icon="arrow-down"-->
-<!--     class="block block-menu navigation menu--main cd-nav cd-site-header__nav" data-cd-processed="true">-->
-<!--    <h2 id="block-mainnavigation-menu">Main navigation</h2>-->
-<!--    <ul class="menu">-->
-<!--        <li class="menu-item menu-item--expanded">-->
-<!--            <ul data-cd-toggable="Layouts" data-cd-icon="arrow-down" data-cd-component="cd-main-menu"-->
-<!--                id="cd-main-menu-0-4" class="menu cd-main-menu__dropdown">-->
-<!---->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/node/1" id="cd-main-menu-item-1-1"><span>First sidebar</span></a>-->
-<!--                </li>-->
-<!---->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/node/2" id="cd-main-menu-item-1-2"><span>Second sidebar</span></a>-->
-<!--                </li>-->
-<!---->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/node/3" id="cd-main-menu-item-1-3"><span>Both sidebars</span></a>-->
-<!--                </li>-->
-<!--            </ul>-->
-<!--        </li>-->
-<!---->
-<!--        <li class="menu-item menu-item--expanded">-->
-<!--            <ul data-cd-toggable="Views List" data-cd-icon="arrow-down" data-cd-component="cd-main-menu"-->
-<!--                id="cd-main-menu-0-5" class="menu cd-main-menu__dropdown">-->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/teaser-list" id="cd-main-menu-item-1-1"><span>Teaser List</span></a>-->
-<!--                </li>-->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/card-list" id="cd-main-menu-item-1-2"><span>Card List</span></a>-->
-<!--                </li>-->
-<!--                <li class="menu-item">-->
-<!--                    <a href="/facets" id="cd-main-menu-item-1-3"><span>List with facets</span></a>-->
-<!--                </li>-->
-<!--            </ul>-->
-<!--        </li>-->
-<!--    </ul>-->
-<!--</nav>-->
-<!---->

--- a/resources/templates/nav/nav-top.php
+++ b/resources/templates/nav/nav-top.php
@@ -10,8 +10,56 @@
     <h2 id="block-mainnavigation-menu">Main navigation</h2>
 	<?php
 		wp_nav_menu( array(
-			'theme_location' => 'common_design_top',
-			'menu_class' => 'wp-menu-item',
+			'container'     => 'ul',
+			'theme_location' => 'top',
+			'depth' => '2',
+			'menu_class' => 'menu',
+            'menu_item' => 'menu-item',
+			'link_before' => '<span>',
+            'link_after' => '</span>',
+			'walker' => new cd_MainNav_Walker()
 		) );
 	?>
 </nav>
+
+<!---->
+<!--<nav role="navigation" id="block-mainnavigation" aria-labelledby="block-mainnavigation-menu" data-cd-toggable="Menu"-->
+<!--     data-cd-component="cd-nav" data-cd-icon="arrow-down"-->
+<!--     class="block block-menu navigation menu--main cd-nav cd-site-header__nav" data-cd-processed="true">-->
+<!--    <h2 id="block-mainnavigation-menu">Main navigation</h2>-->
+<!--    <ul class="menu">-->
+<!--        <li class="menu-item menu-item--expanded">-->
+<!--            <ul data-cd-toggable="Layouts" data-cd-icon="arrow-down" data-cd-component="cd-main-menu"-->
+<!--                id="cd-main-menu-0-4" class="menu cd-main-menu__dropdown">-->
+<!---->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/node/1" id="cd-main-menu-item-1-1"><span>First sidebar</span></a>-->
+<!--                </li>-->
+<!---->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/node/2" id="cd-main-menu-item-1-2"><span>Second sidebar</span></a>-->
+<!--                </li>-->
+<!---->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/node/3" id="cd-main-menu-item-1-3"><span>Both sidebars</span></a>-->
+<!--                </li>-->
+<!--            </ul>-->
+<!--        </li>-->
+<!---->
+<!--        <li class="menu-item menu-item--expanded">-->
+<!--            <ul data-cd-toggable="Views List" data-cd-icon="arrow-down" data-cd-component="cd-main-menu"-->
+<!--                id="cd-main-menu-0-5" class="menu cd-main-menu__dropdown">-->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/teaser-list" id="cd-main-menu-item-1-1"><span>Teaser List</span></a>-->
+<!--                </li>-->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/card-list" id="cd-main-menu-item-1-2"><span>Card List</span></a>-->
+<!--                </li>-->
+<!--                <li class="menu-item">-->
+<!--                    <a href="/facets" id="cd-main-menu-item-1-3"><span>List with facets</span></a>-->
+<!--                </li>-->
+<!--            </ul>-->
+<!--        </li>-->
+<!--    </ul>-->
+<!--</nav>-->
+<!---->

--- a/resources/templates/parts/parts-header.php
+++ b/resources/templates/parts/parts-header.php
@@ -28,104 +28,20 @@
         </div>
 	</div>
 
-<!-- white lower header -->
 	<div class="cd-site-header">
 	  		<div class="cd-container cd-site-header__inner">
 
-	    		<!-- blue ocha logo-->
 	  			<div class="region region-header-logo">
-	  			  	<!-- <a href="/" title="Home" rel="home" class="cd-site-logo"> -->
 	  			  	 <?php the_Custom_logo(); ?>
-
-
-	  						<!-- question : do I need to wrap the custom logo php in img? Also I don't know why if I don't use </img> it shows the last php angle bracket -->
-					<!-- </a> -->
 	  			</div>
 
-	  	<!-- menu connected for wp found in nav-top.php -->
-
-
-
-	  			<!-- menu options container-->
 	   			<div class="cd-site-header__actions">
-	   				<!-- menu options search-->
-	   				<!-- -->
-	        		<div class="cd-search">
-						<button type="button" id="block-searchform-toggler" class="cd-search__btn" data-cd-toggler="" aria-expanded="false" aria-haspopup="true" aria-controls="block-searchform">
-							<svg width="16" height="16" aria-hidden="true" focusable="false" class="cd-icon cd-icon--search cd-search__logo">
-								<use xlink:href="#cd-icon--search"></use>
-							</svg>
-							<span class="cd-search__btn-label">Search</span>
-						</button>
-						<div class="search-block-form cd-search__form block block-search" data-drupal-selector="search-block-form" aria-labelledby="cd-search-form" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-searchform" role="search" data-cd-hidden="true" data-cd-processed="true">
-	      					<h2 class="visually-hidden" id="cd-search-form">Search form</h2>
-	      					<!-- add php for search form -->
-	  						<?php get_search_form(); ?>
-							<form action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8" class="cd-flow">
-		  						<div class="js-form-item form-item js-form-type-search form-item-keys js-form-item-keys form-no-label cd-form__item">
-		      						<label for="edit-keys" class="visually-hidden">Search</label>
-		        						<input title="Enter the terms you wish to search for." placeholder="What are you looking for?" class="cd-search__input form-search" id="cd-search" autocomplete="off" data-drupal-selector="edit-keys" type="search" name="keys" value="" size="15" maxlength="128">
-		        				</div>
-								<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">
-									<button data-twig-suggestion="search_submit" class="cd-search__submit button js-form-submit form-submit" value="Search" data-drupal-selector="edit-submit" type="submit" id="edit-submit">
-		  								<svg class="cd-icon cd-icon--search" width="16" height="16">
-		    								<use xlink:href="#cd-icon--search"></use>
-		  								</svg>
-		  								<span class="visually-hidden">Search</span>
-									</button>
-								</div>
-							</form>
-	  					</div>
-	  				</div>
-
-					<div class="cd-site-header__nav-holder">
-						<?php get_template_part( 'resources/templates/nav/nav', 'top' ); ?>
 
 
-<!--						<nav role="navigation" id="block-mainnavigation" aria-labelledby="block-mainnavigation-menu" data-cd-toggable="Menu" data-cd-component="cd-nav" data-cd-icon="arrow-down" class="block block-menu navigation menu--main cd-nav cd-site-header__nav" data-cd-processed="true">-->
-<!--	  						<h2 id="block-mainnavigation-menu">Main navigation</h2>-->
-<!--							<ul class="menu">-->
-<!--						    	<li class="menu-item">-->
-<!--									<a href="/demo" id="cd-main-menu-item-0-1"><span>Common design demo</span></a>-->
-<!--						    	</li>-->
-<!--	     						<li class="menu-item">-->
-<!--									<a href="/svg-icon-library" id="cd-main-menu-item-0-2"><span>Icons</span></a>-->
-<!--								</li>-->
-<!--								<li class="menu-item">-->
-<!--									<a href="https://brand.unocha.org" id="cd-main-menu-item-0-3"><span>Brand guidelines</span></a>-->
-<!--								</li>-->
-<!--	 							<li class="menu-item menu-item--expanded">-->
-<!--	    							<button type="button" id="cd-main-menu-0-4-toggler" class="cd-main-menu__btn" data-cd-toggler="" aria-expanded="false" aria-haspopup="true" aria-controls="cd-main-menu-0-4"><span class="cd-main-menu__btn-label">Layouts</span><svg width="16" height="16" aria-hidden="true" focusable="false" class="cd-icon cd-icon--arrow-down cd-main-menu__icon"><use xlink:href="#cd-icon--arrow-down"></use></svg></button>-->
-<!--	    							<ul data-cd-toggable="Layouts" data-cd-icon="arrow-down" data-cd-component="cd-main-menu" id="cd-main-menu-0-4" class="menu cd-main-menu__dropdown" data-cd-hidden="true" data-cd-processed="true">-->
-<!--								        <li class="menu-item">-->
-<!--											<a href="/node/1" id="cd-main-menu-item-1-1"><span>First sidebar</span></a>-->
-<!--								    	</li>-->
-<!--								      	<li class="menu-item">-->
-<!--								            <a href="/node/2" id="cd-main-menu-item-1-2"><span>Second sidebar</span></a>-->
-<!--								    	</li>-->
-<!--									    <li class="menu-item">-->
-<!--											<a href="/node/3" id="cd-main-menu-item-1-3"><span>Both sidebars</span></a>-->
-<!--									    </li>-->
-<!--									</ul>-->
-<!--								</li>-->
-<!--	      						<li class="menu-item menu-item--expanded">-->
-<!--	      							<button type="button" id="cd-main-menu-0-5-toggler" class="cd-main-menu__btn" data-cd-toggler="" aria-expanded="false" aria-haspopup="true" aria-controls="cd-main-menu-0-5"><span class="cd-main-menu__btn-label">Views List</span><svg width="16" height="16" aria-hidden="true" focusable="false" class="cd-icon cd-icon--arrow-down cd-main-menu__icon"><use xlink:href="#cd-icon--arrow-down"></use></svg></button>-->
-<!--	      							<ul data-cd-toggable="Views List" data-cd-icon="arrow-down" data-cd-component="cd-main-menu" id="cd-main-menu-0-5" class="menu cd-main-menu__dropdown" data-cd-hidden="true" data-cd-processed="true">-->
-<!--	      								<li class="menu-item">-->
-<!--	      									<a href="/teaser-list" id="cd-main-menu-item-1-1"><span>Teaser List</span></a>-->
-<!--	      								</li>-->
-<!--									    <li class="menu-item">-->
-<!--											<a href="/card-list" id="cd-main-menu-item-1-2"><span>Card List</span></a>-->
-<!--									    </li>-->
-<!--									    <li class="menu-item">-->
-<!--											<a href="/facets" id="cd-main-menu-item-1-3"><span>List with facets</span></a>-->
-<!--									    </li>-->
-<!---->
-<!--	       							</ul>-->
-<!--	       						</li>-->
-<!--	       					 </ul>-->
-<!--						</nav>-->
-					</div>
+                    <div class="cd-site-header__nav-holder">
+                        <?php get_template_part( 'resources/templates/nav/nav', 'top' ); ?>
+
+                    </div>
 
     		</div>
   		</div>


### PR DESCRIPTION
Php functions to generate the markup needed for the cd-dropdown to work on a Wordpress menu created via the UI with a nested menu. The Parent item gets replaced with a `<button>` element and the nested `<ul>` (sub menu) is hidden on load and revealed on click.

![Selection_012](https://user-images.githubusercontent.com/1835923/120664681-6d689200-c48b-11eb-9b0f-abd6ff1beedb.png)

![Selection_013](https://user-images.githubusercontent.com/1835923/120667665-026c8a80-c48e-11eb-8335-c348cb4b8d13.png)
