### PR TITLE
CD-289 Editor stylesheet

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -39,6 +39,13 @@ function common_design_theme_scripts() {
 add_action( 'wp_enqueue_scripts', 'common_design_theme_stylesheets' );
 add_action( 'wp_enqueue_scripts', 'common_design_theme_scripts' );
 
+/* Add Common Design styles to the Gutenburg blocks on the Edit page */
+function common_design_theme_editor_styles(){
+	add_theme_support( 'editor-styles' );
+	add_editor_style( get_template_directory_uri().'/resources/assets/css/style-editor.css' );
+}
+add_action( 'after_setup_theme', 'common_design_theme_editor_styles' );
+
 /**
  * Add "menu-item--expanded" class to parent menu items.
  */

--- a/resources/assets/css/style-editor.css
+++ b/resources/assets/css/style-editor.css
@@ -1,0 +1,3 @@
+.wp-block-buttons {
+    background: red;
+}


### PR DESCRIPTION
@anna-prince After some googling, it seems this is how we can override the editor styles. I _think_ the files needs to be named `style-editor.css` and it seems the styles get added as inline styles in the editor.
Note in the screenshot the selector is `.editor-styles-wrapper .wp-block-buttons {}` whereas the selector I've used for the rule is
```
.wp-block-buttons {
    background: red;
}
```

![Selection_040](https://user-images.githubusercontent.com/1835923/125652516-ace67c55-a091-4e27-aaf2-7ae5173682b3.png)


I imagine we will end up copying the rules you add in styles.css for the CD components like button, to `style-editor.css` so more duplication but I currently can't see a way around this.
