### PR TITLE
CD-289 Thumbnail images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -388,7 +388,7 @@ add_action( 'after_setup_theme', 'common_design_disable_gutenberg_color_settings
 
 
 // Image size for teaser thumbnails
-add_image_size( 'thumbnail-teaser', 384, 288 );
+add_image_size( 'thumbnail-teaser', 600, 450 );
 //add_image_size( 'sidebar-thumb', 120, 120, true ); // Hard Crop Mode
 //add_image_size( 'homepage-thumb', 220, 180 ); // Soft Crop Mode
 //add_image_size( 'singlepost-thumb', 590, 9999 ); // Unlimited Height Mode

--- a/functions.php
+++ b/functions.php
@@ -383,3 +383,12 @@ function common_design_disable_gutenberg_color_settings() {
 	add_theme_support( 'disable-custom-gradients' );
 }
 add_action( 'after_setup_theme', 'common_design_disable_gutenberg_color_settings' );
+
+
+
+
+// Image size for teaser thumbnails
+add_image_size( 'thumbnail-teaser', 384, 288 );
+//add_image_size( 'sidebar-thumb', 120, 120, true ); // Hard Crop Mode
+//add_image_size( 'homepage-thumb', 220, 180 ); // Soft Crop Mode
+//add_image_size( 'singlepost-thumb', 590, 9999 ); // Unlimited Height Mode

--- a/resources/templates/common/common-article--teaser.php
+++ b/resources/templates/common/common-article--teaser.php
@@ -8,7 +8,7 @@
 
 	<?php if ( has_post_thumbnail() ) : ?>
         <div class="cd-teaser__image">
-            <?php the_post_thumbnail(); ?>
+	        <?php the_post_thumbnail( 'thumbnail-teaser' ); ?>
         </div>
 	<?php endif; ?>
 


### PR DESCRIPTION
1. Set thumbnail image styles and comment out some examples with different crop options
2. Use thumbnail style in teaser template

To prevent the Feature image displaying at its largest dimension on desktop, when the teaser image container is width restricted at 384px.