### PR TITLE
CD-320 cd-banner image 

### DIFF
--- a/resources/assets/css/cd-overrides.css
+++ b/resources/assets/css/cd-overrides.css
@@ -283,6 +283,10 @@ ul.wp-block-page-list li {
 .cd-banner {
   margin-bottom: 2rem;
 }
+/* Stretch to fit available space */
+.cd-banner__image {
+  object-fit: cover;
+}
 
 /* Youtube embed */
 .is-type-video .wp-block-embed__wrapper {


### PR DESCRIPTION
override rule to use `object-fit: cover` so image is stretched to fit available space if orig is not wide enough