### PR TITLE
[CD-552] Tweaks based on Strattic work

### DIFF
--- a/resources/assets/css/cd-overrides.css
+++ b/resources/assets/css/cd-overrides.css
@@ -265,11 +265,16 @@ ol {
 }
 
 /* Latest Posts Gutenberg block styles */
+.wp-block-latest-posts__list {
+  max-width: none;
+}
+
 .wp-block-latest-posts__list li:after {
   display: table;
   clear: both;
   content: "";
 }
+
 .wp-block-latest-posts__list li {
   max-width: var(--cd-max-content-width);
   margin-bottom: 1rem;

--- a/resources/assets/css/cd/cd-footer/cd-footer-mandate.css
+++ b/resources/assets/css/cd/cd-footer/cd-footer-mandate.css
@@ -13,11 +13,13 @@
 }
 
 .cd-mandate__logo {
+  position: relative;
+  top: -3px;
   display: block;
   width: 149px;
   height: 37px;
-  margin-inline: auto;
   margin-block-end: 1rem;
+  margin-inline: auto;
 }
 
 .cd-mandate__text {

--- a/resources/assets/css/cd/cd-footer/cd-ocha.css
+++ b/resources/assets/css/cd/cd-footer/cd-ocha.css
@@ -16,7 +16,7 @@
     height: 1px;
     content: '';
     opacity: 0.6;
-    background: var(--cd-white);
+    background: currentColor;
 
   }
 


### PR DESCRIPTION
Refs: CD-552

- Mandate logo nudged
- OCHA Services separator uses `currentColor` so it automatically matches text.
- WP Latest Posts block now fills container width